### PR TITLE
Refactor: security 코드 리팩토링 #20

### DIFF
--- a/src/main/java/com/turing/forseason/domain/user/controller/login/UserController.java
+++ b/src/main/java/com/turing/forseason/domain/user/controller/login/UserController.java
@@ -7,7 +7,7 @@ import com.turing.forseason.domain.user.entity.UserEntity;
 import com.turing.forseason.domain.user.service.UserService;
 import com.turing.forseason.global.dto.ApplicationResponse;
 import com.turing.forseason.global.errorException.ErrorCode;
-import com.turing.forseason.global.jwt.JwtProperties;
+import com.turing.forseason.global.jwt.JwtTokenProvider;
 import com.turing.forseason.global.jwt.OauthToken;
 import com.turing.forseason.global.jwt.PrincipalDetails;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,7 +32,7 @@ public class UserController {
         System.out.println("jwt 토큰 발급");
         System.out.println(jwtToken);
 
-        return ApplicationResponse.ok(ErrorCode.SUCCESS_CREATED, JwtProperties.TOKEN_PREFIX + jwtToken);
+        return ApplicationResponse.ok(ErrorCode.SUCCESS_CREATED, JwtTokenProvider.TOKEN_PREFIX + jwtToken);
     }
 
     @GetMapping("/auth/me")

--- a/src/main/java/com/turing/forseason/domain/user/service/UserService.java
+++ b/src/main/java/com/turing/forseason/domain/user/service/UserService.java
@@ -14,7 +14,7 @@ import com.turing.forseason.domain.user.entity.UserEntity;
 import com.turing.forseason.domain.user.repository.UserRepository;
 import com.turing.forseason.global.errorException.CustomException;
 import com.turing.forseason.global.errorException.ErrorCode;
-import com.turing.forseason.global.jwt.JwtProperties;
+import com.turing.forseason.global.jwt.JwtTokenProvider;
 import com.turing.forseason.global.jwt.OauthToken;
 import com.turing.forseason.global.jwt.PrincipalDetails;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +38,7 @@ import java.util.NoSuchElementException;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final JwtTokenProvider tokenProvider;
 
     public UserEntity getUserById(Long userId) {
 
@@ -162,26 +163,8 @@ public class UserService {
             userRepository.save(user);
         }
 
-        return createToken(user); // 리턴값 고쳤습니다
+        return tokenProvider.generateToken(user); // 리턴값 고쳤습니다
 
-    }
-
-    public String createToken(UserEntity user) {
-
-
-        String jwtToken = JWT.create()
-
-                .withSubject(user.getUserEmail())
-                .withExpiresAt(new Date(System.currentTimeMillis()+ JwtProperties.EXPIRATION_TIME))
-
-                .withClaim("id", user.getUserId())
-                .withClaim("nickname", user.getUserName())
-
-                .sign(Algorithm.HMAC512(JwtProperties.SECRET));
-
-        System.out.println(JwtProperties.SECRET);
-
-        return jwtToken;
     }
 
     public UserEntity getUser(HttpServletRequest request) {

--- a/src/main/java/com/turing/forseason/global/config/security/JwtSecurityConfig.java
+++ b/src/main/java/com/turing/forseason/global/config/security/JwtSecurityConfig.java
@@ -1,26 +1,24 @@
 package com.turing.forseason.global.config.security;
 
 import com.turing.forseason.domain.user.repository.UserRepository;
+import com.turing.forseason.global.jwt.JwtAccessDeniedHandler;
+import com.turing.forseason.global.jwt.JwtAuthenticationEntryPoint;
 import com.turing.forseason.global.jwt.JwtRequestFilter;
+import com.turing.forseason.global.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.DefaultSecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-// Configuration 어노테이션 안붙여도 되나...?
+@Configuration
+@RequiredArgsConstructor
 public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
-    private UserRepository userRepository;
-    public JwtSecurityConfig(UserRepository userRepository) {
-        this.userRepository = userRepository;
-    }
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Override
-    public void configure(HttpSecurity http) {
-        http.addFilterBefore(
-                // UsernamePasswordAuthenticationFilter이전에 JwtRequestFilter를 거치도록 등록
-                // UsernamePasswordAuthenticationFilter: 사용자의 아이디와 비밀번호를 기반으로 인증하는 역할
-                new JwtRequestFilter(userRepository),
-                UsernamePasswordAuthenticationFilter.class
-        );
+    public void configure(HttpSecurity http) throws Exception{
+        http.addFilterBefore(new JwtRequestFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
     }
 }

--- a/src/main/java/com/turing/forseason/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/turing/forseason/global/config/security/SecurityConfig.java
@@ -28,8 +28,7 @@ import java.util.Arrays;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    @Autowired
-    private final UserRepository userRepository;
+    private final JwtSecurityConfig jwtSecurityConfig;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -54,13 +53,14 @@ public class SecurityConfig {
                         "https://kauth.kakao.com/oauth/token", "https://kapi.kakao.com/v2/user/me", "/stomp/talk/**", "/talk/user/delete").permitAll()
                 // 위 URL 제외하고는 모두 인증필요
                 .anyRequest().authenticated()
-                .and()
-                // 예외 처리 핸들러 설정
-                .exceptionHandling()
-                .authenticationEntryPoint(new JwtAuthenticationEntryPoint())
-                .accessDeniedHandler(new JwtAccessDeniedHandler());
 
-        http.addFilterBefore(new JwtRequestFilter(userRepository), UsernamePasswordAuthenticationFilter.class);
+                .and()
+                .exceptionHandling()
+                .accessDeniedHandler(new JwtAccessDeniedHandler())
+                .authenticationEntryPoint(new JwtAuthenticationEntryPoint())
+
+                .and()
+                .apply(jwtSecurityConfig);
 
         return http.build();
     }

--- a/src/main/java/com/turing/forseason/global/errorException/ErrorCode.java
+++ b/src/main/java/com/turing/forseason/global/errorException/ErrorCode.java
@@ -7,38 +7,44 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 @Getter
 public enum ErrorCode {
+    // 성공 관련(1000번대 코드 사용)
     SUCCESS_OK(HttpStatus.OK, "성공", 1000),
-
     // 정석대로는 헤더필드의 Location에 URI를 넣어서 반환해야되는데 구현 할까요...?
     SUCCESS_CREATED(HttpStatus.CREATED, "생성 성공", 1001),
 
-    INVALID_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않는 토큰입니다.", 2001),
 
-    INVALID_JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다.", 2002),
+    // JWT & Auth 관련(2000번대 코드 사용)
+    JWT_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않는 JWT 서명입니다.", 2001),
+    JWT_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다.", 2002),
+    JWT_UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "지원하지 않는 JWT 토큰입니다.", 2003),
+    JWT_WRONG_TOKEN(HttpStatus.UNAUTHORIZED, "잘못된 JWT 토큰 입니다.", 2004),
+    AUTH_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 정보의 사용자를 찾을 수 없습니다.", 2005),
+    AUTH_INVALID_KAKAO_CODE(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.", 2006),
+    AUTH_EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 엑세스 토큰입니다.", 2007),
+    AUTH_BAD_LOGOUT_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다", 2008),
 
-    AUTH_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 정보의 사용자를 찾을 수 없습니다.", 2003),
 
-    AUTH_INVALID_KAKAO_CODE(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.", 2004),
 
-    AUTH_EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 엑세스 토큰입니다.", 2005),
 
-    AUTH_BAD_LOGOUT_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다", 2006),
-
+    // Board 관련(3000번대 코드 사용)
     BOARD_BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.", 3001),
 
-    // 채팅방 userList에 {userUUID, userID}로 매핑된 정보가 없음
-    TALK_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 정보의 사용자를 찾을 수 없습니다.", 5001),
 
-    // user의 DB 데이터에 접근할 수 없음
-    TALK_USER_ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 정보의 사용자를 찾을 수 없습니다.", 5002),
+    // User 관련(4000번대 코드 사용)
 
-    // 잘못된 location
-    TALK_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 정보의 채팅방을 찾을 수 없습니다.", 5003),
 
-    // 이미 접속중인 사용자
-    TALK_DUPLICATED_USER(HttpStatus.NOT_ACCEPTABLE, "중복된 사용자입니다.", 5004),
+    // comment 관련(5000번대 코드 사용)
 
-    UNKNOWN_ERROR(HttpStatus.BAD_GATEWAY, "알 수 없는 오류입니다",6001),
+
+    // Talk 관련(6000번대 코드 사용)
+    TALK_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 정보의 사용자를 찾을 수 없습니다.", 6001),
+    TALK_USER_ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 정보의 사용자를 찾을 수 없습니다.", 6002),
+    TALK_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 정보의 채팅방을 찾을 수 없습니다.", 6003),
+    TALK_DUPLICATED_USER(HttpStatus.NOT_ACCEPTABLE, "중복된 사용자입니다.", 6004),
+
+
+    // 원인 불명 에러(7000번대 코드 사용)
+    UNKNOWN_ERROR(HttpStatus.BAD_GATEWAY, "알 수 없는 오류입니다",7001),
     ;
 
 

--- a/src/main/java/com/turing/forseason/global/jwt/JwtProperties.java
+++ b/src/main/java/com/turing/forseason/global/jwt/JwtProperties.java
@@ -1,8 +1,0 @@
-package com.turing.forseason.global.jwt;
-
-public interface JwtProperties {
-    String SECRET = "test";
-    int EXPIRATION_TIME =  8640000;
-    String TOKEN_PREFIX = "Bearer ";
-    String HEADER_STRING = "Authorization";
-}

--- a/src/main/java/com/turing/forseason/global/jwt/JwtRequestFilter.java
+++ b/src/main/java/com/turing/forseason/global/jwt/JwtRequestFilter.java
@@ -15,6 +15,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;
@@ -27,69 +28,36 @@ import java.util.NoSuchElementException;
 @RequiredArgsConstructor
 @Component
 public class JwtRequestFilter extends OncePerRequestFilter {
-
-    @Autowired
-    private final UserRepository userRepository;
-
+    private final JwtTokenProvider tokenProvider;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        // 필터링 작업 구현
 
         System.out.println(request.getRequestURI());
 
-        // 헤더정보로부터 JWT 가져오기
-        String jwtHeader = ((HttpServletRequest)request).getHeader(JwtProperties.HEADER_STRING);
-        System.out.println(jwtHeader+"4");
-
-        // 해당 헤더필드가 비어있다면 || bearer가 아니라면
-        if(jwtHeader == null || !jwtHeader.startsWith(JwtProperties.TOKEN_PREFIX)) {
-            // 다음 필터체인을 진행
-            filterChain.doFilter(request, response);
-            return;
-        }
-
-        // JWT 토근 값만 뽑기
-        String token = jwtHeader.replace(JwtProperties.TOKEN_PREFIX, "");
-
-        Long userId = null;
-        String username = null;
-
         try {
-            // 토큰 검증 (이게 인증이기 때문에 AuthenticationManager도 필요 없음)
-            userId = JWT.require(Algorithm.HMAC512(JwtProperties.SECRET)).build().verify(token)
-                    .getClaim("id").asLong();
-            username = JWT.require(Algorithm.HMAC512(JwtProperties.SECRET)).build().verify(token)
-                    .getClaim("nickname").asString();
-            System.out.println(userId+"1");
-            System.out.println(username+"2");
+            // Request Header에서 JWT 토큰 꺼내기
+            String jwt = resolveToken(request);
 
-            // 위 userId로 사용자 찾기
-            UserEntity user = userRepository.findByUserId(userId).orElseThrow(
-                    () -> new CustomException(ErrorCode.AUTH_USER_NOT_FOUND)
-            );
-
-            PrincipalDetails principalDetails = new PrincipalDetails(user);
-
-            Authentication authentication =
-                    new UsernamePasswordAuthenticationToken(
-                            principalDetails, //나중에 컨트롤러에서 DI해서 쓸 때 사용하기 편함.
-                            null, // 패스워드는 모르니까 null 처리, 어차피 지금 인증하는게 아니니까!!
-                            principalDetails.getAuthorities());
-
-            SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        } catch (TokenExpiredException e) {
-            e.printStackTrace();
-            request.setAttribute("exception", ErrorCode.INVALID_JWT_EXPIRED);
-        } catch (JWTVerificationException e) {
-            e.printStackTrace();
-            request.setAttribute("exception", ErrorCode.INVALID_JWT_TOKEN);
+            // 유효성검사
+            if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
+                Authentication authentication = tokenProvider.getAuthentication(jwt);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (CustomException e) {
+            request.setAttribute("exception", e.getErrorCode());
         }
 
-        request.setAttribute("userCode", userId);
-        System.out.println("T.T");
-
-        filterChain.doFilter(request, response);
+        filterChain.doFilter(request,response);
     }
+
+    private String resolveToken(HttpServletRequest request) {
+        String token = request.getHeader(JwtTokenProvider.HEADER_STRING);
+
+        if (StringUtils.hasText(token) && token.startsWith(JwtTokenProvider.TOKEN_PREFIX)) {
+            return token.replace(JwtTokenProvider.TOKEN_PREFIX, "");
+        }
+        return null;
+    }
+
 }

--- a/src/main/java/com/turing/forseason/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/turing/forseason/global/jwt/JwtTokenProvider.java
@@ -7,7 +7,6 @@ import com.turing.forseason.domain.user.entity.UserEntity;
 import com.turing.forseason.domain.user.repository.UserRepository;
 import com.turing.forseason.global.errorException.CustomException;
 import com.turing.forseason.global.errorException.ErrorCode;
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;

--- a/src/main/java/com/turing/forseason/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/turing/forseason/global/jwt/JwtTokenProvider.java
@@ -1,0 +1,82 @@
+package com.turing.forseason.global.jwt;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.*;
+import com.turing.forseason.domain.user.entity.UserEntity;
+import com.turing.forseason.domain.user.repository.UserRepository;
+import com.turing.forseason.global.errorException.CustomException;
+import com.turing.forseason.global.errorException.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+    // 토큰 유효성 검사,발급 등등
+    public static final int EXPIRATION_TIME =  8640000;
+    public static final String TOKEN_PREFIX = "Bearer ";
+    public static final String HEADER_STRING = "Authorization";
+
+    private final String key;
+    private final UserRepository userRepository;
+
+    @Autowired
+    public JwtTokenProvider(@Value("${jwt.secret}") String secretKey, UserRepository userRepository) {
+        this.key = secretKey;
+        this.userRepository = userRepository;
+    }
+
+    public String generateToken(UserEntity user) {
+        long now = (new Date()).getTime();
+
+        // Access Token 생성
+        Date tokenExpiresIn = new Date(now + EXPIRATION_TIME);
+        String token = JWT.create()
+                .withSubject(user.getUserEmail())                                       // payload "sub": "userEmail"
+                .withClaim("id", user.getUserId())                                // payload "id": "userId"
+                .withClaim("name", user.getUserNickname())                        // payload "name": "userNickname"
+                .withExpiresAt(tokenExpiresIn)
+                .sign(Algorithm.HMAC256(key));                                          // header "alg": "HS256"
+
+        return token;
+    }
+
+    public Authentication getAuthentication(String token) {
+        // Authentication 객체 만들기
+        Long userId = JWT.require(Algorithm.HMAC256(key)).build().verify(token).getClaim("id").asLong();
+
+        UserEntity user = userRepository.findById(userId).orElseThrow(
+                () -> new CustomException(ErrorCode.AUTH_USER_NOT_FOUND)
+        );
+
+        PrincipalDetails principalDetails = new PrincipalDetails(user);
+
+        return new UsernamePasswordAuthenticationToken(
+                principalDetails,
+                "",
+                principalDetails.getAuthorities()
+        );
+    }
+
+    public boolean validateToken(String token) {
+
+        try {
+            JWT.require(Algorithm.HMAC256(key)).build().verify(token);
+            return true;
+        } catch (SignatureVerificationException e) {
+            throw new CustomException(ErrorCode.JWT_INVALID_TOKEN);
+        } catch (TokenExpiredException e) {
+            throw new CustomException(ErrorCode.JWT_EXPIRED_TOKEN);
+        } catch (AlgorithmMismatchException | JWTDecodeException e) {
+            throw new CustomException(ErrorCode.JWT_UNSUPPORTED_TOKEN);
+        } catch (JWTVerificationException e) {
+            throw new CustomException(ErrorCode.JWT_WRONG_TOKEN);
+        }
+    }
+}

--- a/src/main/resources/application-oauth2.properties
+++ b/src/main/resources/application-oauth2.properties
@@ -14,6 +14,6 @@ spring.security.oauth2.client.provider.kakao.user-info-uri=https://kapi.kakao.co
 spring.security.oauth2.client.provider.kakao.user-name-attribute=id
 
 
-#jwt.secret=aGVsbG9teW5hbWVpc21ldGFtb25naXdhbnR0b2JlYUNoYXJtYW5kZXJjaGFybWFuZGVyc3RhaWxpc2ZpcmVwaWNhcGljYQ==
+jwt.secret=aGVsbG9teW5hbWVpc21ldGFtb25naXdhbnR0b2JlYUNoYXJtYW5kZXJjaGFybWFuZGVyc3RhaWxpc2ZpcmVwaWNhcGljYQ==
 jwt.header=Authorization
 jwt.token-validity-in-seconds=86400


### PR DESCRIPTION
# PR Summary
- #20

## PR Detail Description
주요 작업
- **JwtSecurityConfig** 작성 및 SecurityConfig에 apply
- **JwtTokenProvider** 작성
- **JwtRequestFilter**를 JwtTokenProvider를 사용하도록 변경
- **JwtProperties** 삭제
- **UserService**의 createToken 메서드 삭제
- **ErrorCode**에 JWT 관련 에러코드 다수 추가
- STOMP의 **PreHandler**를 JwtTokenProvider를 사용하도록 변경

주요 사항
- 토큰을 관리할때는 JwtTokenProvider의 메서드를 통해 하도록 설계
- 기존의 JwtProperties의 필드들을 JwtTokenProvider로 편입
- JWT 알고리즘을 HMAC512에서 HMAC256으로 변경: HMAC256으로도 충분한 보안성을 갖추며, 속도가 더 빠르기 때문.

## Screenshots (Optional)
### JwtTokenProvider
![qwer](https://github.com/Turing-ForSeason/forseason-BE/assets/138233569/8b002b24-a553-4162-b581-a6833cd4f635)
위 사진은 JwtTokenProvider 클래스의 구성입니다.

기존에 JwtProperties에 존재하던 필드들을 JwtTokenProvider에 편입하여, 아래와 같이 사용할 수 있습니다.
![image](https://github.com/Turing-ForSeason/forseason-BE/assets/138233569/5549471e-10ff-4755-8941-b16919b40cb6)


JwtTokenProvider의 메서드는 크게 3가지로 나뉘며,
- 토큰을 생성하는 generateToken()
- 주어진 토큰으로 Authentication 객체를 생성하는 getAuthentication()
- 토큰의 유효성을 검사하는 validateToken()
로 나뉩니다.

+추후 더 필요하신 메서드를 요청하시면 추가하겠습니다.

### JwtRequestFilter
![asdf](https://github.com/Turing-ForSeason/forseason-BE/assets/138233569/efd56290-7540-42d4-9f3a-d345d703a0e5)
기존의 JwtRequestFilter는 단일 책임의 원칙을 위배하고 있다는 판단이 들어, Jwt 토큰을 관리하는 로직과, 필터로써 져야할 책임을 분리하였습니다.
Jwt 토큰을 관리하는 로직은 JwtTokenProvider로 작성하여 이를 활용하도록 코드를 개선하였습니다.