### PR TITLE
Feat: refresh 토큰 분리, reissue로직 및 토큰 블랙리스트 추가 로직 구현

### DIFF
--- a/src/main/java/com/turing/forseason/domain/user/controller/auth/AuthController.java
+++ b/src/main/java/com/turing/forseason/domain/user/controller/auth/AuthController.java
@@ -1,4 +1,4 @@
-package com.turing.forseason.domain.user.controller.login;
+package com.turing.forseason.domain.user.controller.auth;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.interfaces.DecodedJWT;

--- a/src/main/java/com/turing/forseason/domain/user/controller/login/AuthController.java
+++ b/src/main/java/com/turing/forseason/domain/user/controller/login/AuthController.java
@@ -76,14 +76,14 @@ public class AuthController {
     }
 
 
-    @PostMapping("/logout/service")
+    @PostMapping("/auth/logout")
     public ApplicationResponse<String> serviceLogout(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                      @RequestBody JwtTokenDto jwtTokenDto) {
         // 로그아웃: JwtToken 만료시키기 & 카카오 로그인일 경우, OauthToken 또한 만료시키기.
         System.out.println("서비스 로그아웃");
         authService.deprecateTokens(jwtTokenDto);
         kakaoAuthService.serviceLogout(principalDetails);
-        return ApplicationResponse.ok(ErrorCode.SUCCESS_OK, "서비스 로그아웃 되었습니다.");
+        return ApplicationResponse.ok(ErrorCode.SUCCESS_OK, "성공적으로 로그아웃되었습니다.");
     }
 
 

--- a/src/main/java/com/turing/forseason/domain/user/controller/login/AuthController.java
+++ b/src/main/java/com/turing/forseason/domain/user/controller/login/AuthController.java
@@ -76,10 +76,12 @@ public class AuthController {
     }
 
 
-    @GetMapping("/logout/service")
-    public ApplicationResponse<String> serviceLogout(@AuthenticationPrincipal PrincipalDetails principalDetails) {
-        // 서비스 로그아웃 (토큰 만료시키기)
+    @PostMapping("/logout/service")
+    public ApplicationResponse<String> serviceLogout(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                     @RequestBody JwtTokenDto jwtTokenDto) {
+        // 로그아웃: JwtToken 만료시키기 & 카카오 로그인일 경우, OauthToken 또한 만료시키기.
         System.out.println("서비스 로그아웃");
+        authService.deprecateTokens(jwtTokenDto);
         kakaoAuthService.serviceLogout(principalDetails);
         return ApplicationResponse.ok(ErrorCode.SUCCESS_OK, "서비스 로그아웃 되었습니다.");
     }
@@ -122,6 +124,7 @@ public class AuthController {
 
         return ApplicationResponse.ok(ErrorCode.SUCCESS_OK, jwtTokenDto);
     }
+
 
     // 밑의 코드들은 전부 Test 용
     @GetMapping("test/oauthtoken/expried")

--- a/src/main/java/com/turing/forseason/domain/user/controller/login/AuthController.java
+++ b/src/main/java/com/turing/forseason/domain/user/controller/login/AuthController.java
@@ -3,11 +3,13 @@ package com.turing.forseason.domain.user.controller.login;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.turing.forseason.domain.user.domain.KakaoProfile;
-import com.turing.forseason.domain.user.dto.EmailVerificationDto;
-import com.turing.forseason.domain.user.dto.SignInRequestDto;
-import com.turing.forseason.domain.user.dto.SignUpRequestDto;
-import com.turing.forseason.domain.user.dto.UserDetailDto;
+import com.turing.forseason.domain.user.dto.*;
+import com.turing.forseason.domain.user.dto.auth.EmailVerificationDto;
+import com.turing.forseason.domain.user.dto.auth.ReissueRequestDto;
+import com.turing.forseason.domain.user.dto.auth.SignInRequestDto;
+import com.turing.forseason.domain.user.dto.auth.SignUpRequestDto;
 import com.turing.forseason.domain.user.entity.UserEntity;
+import com.turing.forseason.domain.user.service.AuthService;
 import com.turing.forseason.domain.user.service.GeneralAuthService;
 import com.turing.forseason.domain.user.service.KakaoAuthService;
 import com.turing.forseason.domain.user.service.UserService;
@@ -29,6 +31,7 @@ public class AuthController {
     private final UserService userService;
     private final GeneralAuthService generalAuthService;
     private final KakaoAuthService kakaoAuthService;
+    private final AuthService authService;
 
     @GetMapping("/api/login/oauth2/code/kakao")
     public ApplicationResponse<JwtTokenDto> Login(@RequestParam("code") String code) {
@@ -39,7 +42,8 @@ public class AuthController {
         System.out.println(oauthToken);
         JwtTokenDto jwtTokenDto = kakaoAuthService.saveUserAndGetToken(oauthToken);
         System.out.println("jwt 토큰 발급");
-        System.out.println(jwtTokenDto);
+        System.out.println(jwtTokenDto.getAccessToken());
+        System.out.println(jwtTokenDto.getRefreshToken());
 
         return ApplicationResponse.ok(ErrorCode.SUCCESS_CREATED, jwtTokenDto);
     }
@@ -112,6 +116,12 @@ public class AuthController {
         return ApplicationResponse.ok(ErrorCode.SUCCESS_OK, jwtTokenDto);
     }
 
+    @PostMapping("/auth/reissue")
+    public ApplicationResponse<JwtTokenDto> reissue(@RequestBody ReissueRequestDto reissueRequestDto) {
+        JwtTokenDto jwtTokenDto = authService.reissue(reissueRequestDto.getRefreshToken());
+
+        return ApplicationResponse.ok(ErrorCode.SUCCESS_OK, jwtTokenDto);
+    }
 
     // 밑의 코드들은 전부 Test 용
     @GetMapping("test/oauthtoken/expried")

--- a/src/main/java/com/turing/forseason/domain/user/controller/login/AuthController.java
+++ b/src/main/java/com/turing/forseason/domain/user/controller/login/AuthController.java
@@ -8,17 +8,16 @@ import com.turing.forseason.domain.user.dto.SignInRequestDto;
 import com.turing.forseason.domain.user.dto.SignUpRequestDto;
 import com.turing.forseason.domain.user.dto.UserDetailDto;
 import com.turing.forseason.domain.user.entity.UserEntity;
+import com.turing.forseason.domain.user.service.GeneralAuthService;
+import com.turing.forseason.domain.user.service.KakaoAuthService;
 import com.turing.forseason.domain.user.service.UserService;
 import com.turing.forseason.global.dto.ApplicationResponse;
 import com.turing.forseason.global.errorException.ErrorCode;
-import com.turing.forseason.global.jwt.JwtTokenProvider;
+import com.turing.forseason.global.jwt.JwtTokenDto;
 import com.turing.forseason.global.jwt.OauthToken;
 import com.turing.forseason.global.jwt.PrincipalDetails;
-import com.turing.forseason.global.redis.RedisService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
@@ -26,22 +25,23 @@ import javax.servlet.http.HttpServletRequest;
 @CrossOrigin(origins = "*")
 @RestController
 @RequiredArgsConstructor
-public class UserController {
+public class AuthController {
     private final UserService userService;
-    private final RedisService redisService;
+    private final GeneralAuthService generalAuthService;
+    private final KakaoAuthService kakaoAuthService;
 
     @GetMapping("/api/login/oauth2/code/kakao")
-    public ApplicationResponse<String> Login(@RequestParam("code") String code) {
+    public ApplicationResponse<JwtTokenDto> Login(@RequestParam("code") String code) {
 
         // 카카오로부터 OauthToken 발급받기
-        OauthToken oauthToken = userService.getKakaoAccessToken(code);
+        OauthToken oauthToken = kakaoAuthService.getKakaoAccessToken(code);
         // 발급 받은 OauthToken 으로 카카오 회원 정보 DB 저장 후 JWT 를 생성
         System.out.println(oauthToken);
-        String jwtToken = userService.saveUserAndGetToken(oauthToken);
+        JwtTokenDto jwtTokenDto = kakaoAuthService.saveUserAndGetToken(oauthToken);
         System.out.println("jwt 토큰 발급");
-        System.out.println(jwtToken);
+        System.out.println(jwtTokenDto);
 
-        return ApplicationResponse.ok(ErrorCode.SUCCESS_CREATED, JwtTokenProvider.TOKEN_PREFIX + jwtToken);
+        return ApplicationResponse.ok(ErrorCode.SUCCESS_CREATED, jwtTokenDto);
     }
 
     @GetMapping("/auth/me")
@@ -76,7 +76,7 @@ public class UserController {
     public ApplicationResponse<String> serviceLogout(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         // 서비스 로그아웃 (토큰 만료시키기)
         System.out.println("서비스 로그아웃");
-        userService.serviceLogout(principalDetails);
+        kakaoAuthService.serviceLogout(principalDetails);
         return ApplicationResponse.ok(ErrorCode.SUCCESS_OK, "서비스 로그아웃 되었습니다.");
     }
 
@@ -84,14 +84,14 @@ public class UserController {
     // 여기서부터는 일반로그인
     @GetMapping("/signup/verification/email")
     public ApplicationResponse<String> getEmailAuthCode(@RequestParam(name = "email") String email) {
-        if(userService.isDuplicatedEmail(email))
-            userService.sendEmailAuthCode(email);
+        if(generalAuthService.isDuplicatedEmail(email))
+            generalAuthService.sendEmailAuthCode(email);
         return ApplicationResponse.ok(ErrorCode.SUCCESS_OK, "인증 코드가 전송되었습니다.");
     }
 
     @PostMapping("/signup/verification/email")
     public ApplicationResponse<String> verifyEmail(@RequestBody EmailVerificationDto emailVerificationDto) {
-        userService.verifyEmail(emailVerificationDto);
+        generalAuthService.verifyEmail(emailVerificationDto);
         return ApplicationResponse.ok(ErrorCode.SUCCESS_OK, "인증에 성공하였습니다.");
     }
 
@@ -99,17 +99,17 @@ public class UserController {
     public ApplicationResponse<String> generalSignUp(@RequestBody SignUpRequestDto requestDto) {
         // 코드 리팩토링 필수(URI 설정, 비밀번호 암호화 등)
         System.out.println("일반 회원가입");
-        userService.signUpUser(requestDto);
+        generalAuthService.signUpUser(requestDto);
         return ApplicationResponse.ok(ErrorCode.SUCCESS_CREATED, "회원가입 성공");
     }
 
     @PostMapping("/signin/general")
-    public ApplicationResponse<String> generalSignIn(@RequestBody SignInRequestDto requestDto) {
+    public ApplicationResponse<JwtTokenDto> generalSignIn(@RequestBody SignInRequestDto requestDto) {
         System.out.println("일반 로그인");
-        String jwtToken = userService.signInAndGetToken(requestDto);
-        System.out.println(jwtToken);
+        JwtTokenDto jwtTokenDto = generalAuthService.signInAndGetToken(requestDto);
+        System.out.println(jwtTokenDto);
 
-        return ApplicationResponse.ok(ErrorCode.SUCCESS_OK, JwtTokenProvider.TOKEN_PREFIX + jwtToken);
+        return ApplicationResponse.ok(ErrorCode.SUCCESS_OK, jwtTokenDto);
     }
 
 
@@ -117,7 +117,7 @@ public class UserController {
     @GetMapping("test/oauthtoken/expried")
     public ApplicationResponse<String> test1(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         UserEntity user = principalDetails.getUser();
-        boolean isExpired = userService.isExpired(user.getUserId());
+        boolean isExpired = kakaoAuthService.isExpired(user.getUserId());
 
         return ApplicationResponse.ok(ErrorCode.SUCCESS_OK, "" + isExpired);
     }
@@ -125,7 +125,7 @@ public class UserController {
     @GetMapping("test/oauthtoken/refresh")
     public ApplicationResponse<OauthToken> test2(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         UserEntity user = principalDetails.getUser();
-        OauthToken newOauthToken = userService.getRefresh(user.getUserId());
+        OauthToken newOauthToken = kakaoAuthService.getRefresh(user.getUserId());
 
         return ApplicationResponse.ok(ErrorCode.SUCCESS_OK, newOauthToken);
     }
@@ -133,9 +133,9 @@ public class UserController {
     @GetMapping("test/oauthtoken/profile")
     public ApplicationResponse<KakaoProfile> test3(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         UserEntity user = principalDetails.getUser();
-        OauthToken oauthToken = userService.getOauthToken(user.getUserId());
+        OauthToken oauthToken = kakaoAuthService.getOauthToken(user.getUserId());
 
-        KakaoProfile kakaoProfile = userService.findProfile(oauthToken);
+        KakaoProfile kakaoProfile = kakaoAuthService.findProfile(oauthToken);
 
         return ApplicationResponse.ok(ErrorCode.SUCCESS_OK, kakaoProfile);
     }

--- a/src/main/java/com/turing/forseason/domain/user/dto/auth/EmailVerificationDto.java
+++ b/src/main/java/com/turing/forseason/domain/user/dto/auth/EmailVerificationDto.java
@@ -1,4 +1,4 @@
-package com.turing.forseason.domain.user.dto;
+package com.turing.forseason.domain.user.dto.auth;
 
 import lombok.Getter;
 

--- a/src/main/java/com/turing/forseason/domain/user/dto/auth/OauthTokenInfoRes.java
+++ b/src/main/java/com/turing/forseason/domain/user/dto/auth/OauthTokenInfoRes.java
@@ -1,4 +1,4 @@
-package com.turing.forseason.domain.user.dto;
+package com.turing.forseason.domain.user.dto.auth;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/turing/forseason/domain/user/dto/auth/ReissueRequestDto.java
+++ b/src/main/java/com/turing/forseason/domain/user/dto/auth/ReissueRequestDto.java
@@ -1,0 +1,8 @@
+package com.turing.forseason.domain.user.dto.auth;
+
+import lombok.Getter;
+
+@Getter
+public class ReissueRequestDto {
+    private String refreshToken;
+}

--- a/src/main/java/com/turing/forseason/domain/user/dto/auth/SignInRequestDto.java
+++ b/src/main/java/com/turing/forseason/domain/user/dto/auth/SignInRequestDto.java
@@ -1,4 +1,4 @@
-package com.turing.forseason.domain.user.dto;
+package com.turing.forseason.domain.user.dto.auth;
 
 import lombok.Getter;
 

--- a/src/main/java/com/turing/forseason/domain/user/dto/auth/SignUpRequestDto.java
+++ b/src/main/java/com/turing/forseason/domain/user/dto/auth/SignUpRequestDto.java
@@ -1,4 +1,4 @@
-package com.turing.forseason.domain.user.dto;
+package com.turing.forseason.domain.user.dto.auth;
 
 import lombok.Getter;
 

--- a/src/main/java/com/turing/forseason/domain/user/service/AuthService.java
+++ b/src/main/java/com/turing/forseason/domain/user/service/AuthService.java
@@ -27,7 +27,7 @@ public class AuthService {
         System.out.println(value);
         if ("Deprecated".equals(value) || !tokenProvider.validateToken(oldRefreshToken)) {
             // refresh 토큰이 블랙리스트에 존재하는지 검사 & 유효성 검사
-            throw new CustomException(ErrorCode.AUTH_INVALID_REFRESH_TOKEN);
+            throw new CustomException(ErrorCode.AUTH_DEPRECATED_REFRESH_TOKEN);
         }
 
         Long userId = Long.valueOf(value);

--- a/src/main/java/com/turing/forseason/domain/user/service/AuthService.java
+++ b/src/main/java/com/turing/forseason/domain/user/service/AuthService.java
@@ -1,0 +1,43 @@
+package com.turing.forseason.domain.user.service;
+
+import com.turing.forseason.domain.user.entity.UserEntity;
+import com.turing.forseason.domain.user.repository.UserRepository;
+import com.turing.forseason.global.errorException.CustomException;
+import com.turing.forseason.global.errorException.ErrorCode;
+import com.turing.forseason.global.jwt.JwtTokenDto;
+import com.turing.forseason.global.jwt.JwtTokenProvider;
+import com.turing.forseason.global.redis.RedisService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthService {
+    private final RedisService redisService;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider tokenProvider;
+
+    public JwtTokenDto reissue(String oldRefreshToken) {
+        String value = (String) redisService.getValue(oldRefreshToken);
+        System.out.println(oldRefreshToken);
+        System.out.println(value);
+        if ("Deprecated".equals(value) || !tokenProvider.validateToken(oldRefreshToken)) {
+            // refresh 토큰이 블랙리스트에 존재하는지 검사 & 유효성 검사
+            throw new CustomException(ErrorCode.AUTH_INVALID_REFRESH_TOKEN);
+        }
+
+        Long userId = Long.valueOf(value);
+        UserEntity user = userRepository.findByUserId(userId).orElseThrow(
+                () -> new CustomException(ErrorCode.AUTH_USER_NOT_FOUND));
+
+        JwtTokenDto jwtTokenDto = tokenProvider.generateToken(user);
+        redisService.setValueWithTTL(oldRefreshToken, "Deprecated", 7L, TimeUnit.DAYS);
+        redisService.setValueWithTTL(jwtTokenDto.getRefreshToken(), userId.toString(), 7L, TimeUnit.DAYS);
+
+        return jwtTokenDto;
+    }
+}

--- a/src/main/java/com/turing/forseason/domain/user/service/AuthService.java
+++ b/src/main/java/com/turing/forseason/domain/user/service/AuthService.java
@@ -40,4 +40,12 @@ public class AuthService {
 
         return jwtTokenDto;
     }
+
+    public void deprecateTokens(JwtTokenDto jwtTokenDto) {
+        String accessToken = jwtTokenDto.getAccessToken().replace(JwtTokenProvider.TOKEN_PREFIX, "");
+        String refreshToken = jwtTokenDto.getRefreshToken();
+
+        redisService.setValueWithTTL(accessToken, "Deprecated", 30L, TimeUnit.MINUTES);
+        redisService.setValueWithTTL(refreshToken, "Deprecated", 7L, TimeUnit.DAYS);
+    }
 }

--- a/src/main/java/com/turing/forseason/domain/user/service/GeneralAuthService.java
+++ b/src/main/java/com/turing/forseason/domain/user/service/GeneralAuthService.java
@@ -1,8 +1,8 @@
 package com.turing.forseason.domain.user.service;
 
-import com.turing.forseason.domain.user.dto.EmailVerificationDto;
-import com.turing.forseason.domain.user.dto.SignInRequestDto;
-import com.turing.forseason.domain.user.dto.SignUpRequestDto;
+import com.turing.forseason.domain.user.dto.auth.EmailVerificationDto;
+import com.turing.forseason.domain.user.dto.auth.SignInRequestDto;
+import com.turing.forseason.domain.user.dto.auth.SignUpRequestDto;
 import com.turing.forseason.domain.user.entity.LoginType;
 import com.turing.forseason.domain.user.entity.Role;
 import com.turing.forseason.domain.user.entity.UserEntity;
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
 @Transactional
 @RequiredArgsConstructor
 public class GeneralAuthService {
-    // 일반 로그인 인증 관련 로직
+    // 일반 로그인 관련 로직
     private final RedisService redisService;
     private final UserRepository userRepository;
     private final JwtTokenProvider tokenProvider;
@@ -67,6 +67,7 @@ public class GeneralAuthService {
             throw new CustomException(ErrorCode.USER_DUPLICATED_USER_EMAIL);
         return true;
     }
+
     @Async
     public void sendEmailAuthCode(String email) {
         // 해당 메서드는 메일 전송후, 잘 전송됐는지 검사까지 하므로 매우 처리시간이 김.

--- a/src/main/java/com/turing/forseason/domain/user/service/GeneralAuthService.java
+++ b/src/main/java/com/turing/forseason/domain/user/service/GeneralAuthService.java
@@ -1,0 +1,107 @@
+package com.turing.forseason.domain.user.service;
+
+import com.turing.forseason.domain.user.dto.EmailVerificationDto;
+import com.turing.forseason.domain.user.dto.SignInRequestDto;
+import com.turing.forseason.domain.user.dto.SignUpRequestDto;
+import com.turing.forseason.domain.user.entity.LoginType;
+import com.turing.forseason.domain.user.entity.Role;
+import com.turing.forseason.domain.user.entity.UserEntity;
+import com.turing.forseason.domain.user.repository.UserRepository;
+import com.turing.forseason.global.errorException.CustomException;
+import com.turing.forseason.global.errorException.ErrorCode;
+import com.turing.forseason.global.jwt.JwtTokenDto;
+import com.turing.forseason.global.jwt.JwtTokenProvider;
+import com.turing.forseason.global.mail.MailService;
+import com.turing.forseason.global.redis.RedisService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class GeneralAuthService {
+    // 일반 로그인 인증 관련 로직
+    private final RedisService redisService;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider tokenProvider;
+    private final MailService mailService;
+
+    public void signUpUser(SignUpRequestDto requestDto) {
+        String state = (String) redisService.getValue(requestDto.getUserEmail());
+        if(!"verified".equals(state)) throw new CustomException(ErrorCode.USER_EMAIL_AUTHENTICATION_STATUS_EXPIRED);
+
+        UserEntity user = UserEntity.builder()
+                .userBoardNum(0L)
+                .userCommentNum(0L)
+                .userEmail(requestDto.getUserEmail())
+                .userPassword(requestDto.getUserPassword())
+                .userNickname(requestDto.getUserNickname())
+                .userName(requestDto.getUserName())
+                .image(requestDto.getImage())
+                .thumbnail(requestDto.getImage())
+                .kakao_id(null)
+                .myRole(Role.MEMBER)
+                .loginType(LoginType.GENERAL)
+                .build();
+
+        userRepository.save(user);
+    }
+
+    public void verifyEmail(EmailVerificationDto emailVerificationDto) {
+        // 인증 코드 검사
+        String authCode = (String) redisService.getValue(emailVerificationDto.getUserEmail());
+
+        if(!emailVerificationDto.getCode().equals(authCode))
+            throw new CustomException(ErrorCode.USER_INVALID_EMAIL_AUTH_CODE);
+
+        redisService.setValueWithTTL(emailVerificationDto.getUserEmail(), "verified", 30, TimeUnit.MINUTES);
+    }
+
+    public boolean isDuplicatedEmail(String email) {
+        // 이메일 중복 검사 메서드
+        if(userRepository.existsByUserEmail(email))
+            throw new CustomException(ErrorCode.USER_DUPLICATED_USER_EMAIL);
+        return true;
+    }
+    @Async
+    public void sendEmailAuthCode(String email) {
+        // 해당 메서드는 메일 전송후, 잘 전송됐는지 검사까지 하므로 매우 처리시간이 김.
+        // 따라서 스레드 비동기 처리로 서버 처리 속도를 향상시킴.
+        // 이메일 인증 코드 전송하기
+
+        String authCode = mailService.generateCode();
+        System.out.println(authCode);
+
+        String body = "";
+        body += "<h3>" + "Forseason 이메일 인증 코드입니다." + "</h3>";
+        body += "<h1>" + authCode + "</h1>";
+        body += "<h3>" + "인증 코드는 30분간 유효합니다." + "</h3>";
+
+        try {
+            mailService.sendEmail(email, "[Forseason] 이메일 인증 코드", body);
+        } catch (Throwable e) {
+            throw new CustomException(ErrorCode.UNKNOWN_ERROR);
+        }
+
+        redisService.setValueWithTTL(email, authCode, 7L, TimeUnit.DAYS);
+    }
+
+
+    public JwtTokenDto signInAndGetToken(SignInRequestDto requestDto) {
+        // Email, PW 검증 후 JWT 토큰 발급 & refresh 토큰 redis에 저장.
+        UserEntity user = userRepository.findByUserEmail(requestDto.getUserEmail()).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_INVALID_EMAIL));
+
+        if(!user.getUserPassword().equals(requestDto.getUserPassword()))
+            throw new CustomException(ErrorCode.USER_INVALID_PASSWORD);
+
+        JwtTokenDto jwtTokenDto = tokenProvider.generateToken(user);
+        redisService.setValueWithTTL(jwtTokenDto.getRefreshToken(), user.getUserId().toString(), 7L, TimeUnit.DAYS);
+
+        return jwtTokenDto;
+    }
+}

--- a/src/main/java/com/turing/forseason/domain/user/service/KakaoAuthService.java
+++ b/src/main/java/com/turing/forseason/domain/user/service/KakaoAuthService.java
@@ -1,0 +1,266 @@
+package com.turing.forseason.domain.user.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.turing.forseason.domain.user.domain.KakaoProfile;
+import com.turing.forseason.domain.user.dto.OauthTokenInfoRes;
+import com.turing.forseason.domain.user.entity.LoginType;
+import com.turing.forseason.domain.user.entity.Role;
+import com.turing.forseason.domain.user.entity.UserEntity;
+import com.turing.forseason.domain.user.repository.UserRepository;
+import com.turing.forseason.global.errorException.CustomException;
+import com.turing.forseason.global.errorException.ErrorCode;
+import com.turing.forseason.global.jwt.JwtTokenDto;
+import com.turing.forseason.global.jwt.JwtTokenProvider;
+import com.turing.forseason.global.jwt.OauthToken;
+import com.turing.forseason.global.jwt.PrincipalDetails;
+import com.turing.forseason.global.redis.RedisService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.NoSuchElementException;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class KakaoAuthService {
+    // 카카오 로그인 인증 관련 로직
+    private final RedisService redisService;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider tokenProvider;
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
+    private String clientSecret;
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String clientId;
+
+    public OauthToken getKakaoAccessToken (String code) {
+        RestTemplate rt = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("redirect_uri", "http://localhost:3000/api/login/oauth2/code/kakao");
+        params.add("code", code);
+        params.add("client_secret", clientSecret);
+
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest =
+                new HttpEntity<>(params, headers);
+
+        ResponseEntity<String> accessTokenResponse = rt.exchange(
+                "https://kauth.kakao.com/oauth/token",
+                HttpMethod.POST,
+                kakaoTokenRequest,
+                String.class
+        );
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        OauthToken oauthToken = null;
+        try {
+            oauthToken = objectMapper.readValue(accessTokenResponse.getBody(), OauthToken.class);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+
+        return oauthToken;
+    }
+
+    public KakaoProfile findProfile(OauthToken oauthToken) {
+
+        String accessToken = oauthToken.getAccess_token();
+
+        // HTTP 메세지 처리 인터페이스 선언
+        RestTemplate rt = new RestTemplate();
+
+
+        // 헤더정보에 token값과 content-type 설정 (kakao에서 지정한 필수 항목)
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken); //(1-4)
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // 위에서 설정한 헤더정보를 담는 HttpEntity 생성
+        HttpEntity<MultiValueMap<String, String>> kakaoProfileRequest = new HttpEntity<>(headers);
+
+        try {
+            // Http 요청 (POST 방식) 후, response 변수에 응답을 받음
+            ResponseEntity<KakaoProfile> kakaoProfileResponse = rt.exchange(
+                    "https://kapi.kakao.com/v2/user/me",
+                    HttpMethod.POST,
+                    kakaoProfileRequest,
+                    KakaoProfile.class
+            );
+
+            System.out.println(kakaoProfileResponse.getBody());
+            return kakaoProfileResponse.getBody();
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.AUTH_EXPIRED_ACCESS_TOKEN);
+        }
+
+    }
+
+
+    public JwtTokenDto saveUserAndGetToken(OauthToken oauthToken) {
+
+        KakaoProfile profile = findProfile(oauthToken);
+
+        System.out.println(profile);
+
+        UserEntity user = null;
+
+        try {
+            user = userRepository.findByUserEmail(profile.getKakao_account().getEmail()).get();
+        } catch (NoSuchElementException e) {
+
+            String userName = "이름넣어줄건가요";
+            Long userBoardNum = 0L;
+            Long userCommentNum = 0L;
+
+
+            user = UserEntity.builder()
+                    .kakao_id(profile.getId())
+                    .image(profile.getKakao_account().getProfile().getProfile_image_url())
+                    .thumbnail(profile.getKakao_account().getProfile().getThumbnail_image_url())
+                    .userNickname(profile.getKakao_account().getProfile().getNickname())
+                    .userEmail(profile.getKakao_account().getEmail())
+                    .userPassword(null)
+                    .myRole(Role.MEMBER)
+                    .loginType(LoginType.KAKAO)
+                    .userName(userName)
+                    .userBoardNum(userBoardNum)
+                    .userCommentNum(userCommentNum)
+                    .build();
+
+            userRepository.save(user);
+        }
+        redisService.setValueWithTTL(user.getUserId().toString(), oauthToken, 7L, TimeUnit.DAYS);
+
+        JwtTokenDto jwtTokenDto = tokenProvider.generateToken(user);
+        redisService.setValueWithTTL(jwtTokenDto.getRefreshToken(), user.getUserId(), 7L, TimeUnit.DAYS);
+
+        return jwtTokenDto;
+    }
+
+    public void serviceLogout(PrincipalDetails principalDetails){
+        // 서비스 로그아웃(카카오)
+        UserEntity user = principalDetails.getUser();
+
+        if(user.getLoginType()!= LoginType.KAKAO)
+            throw new CustomException(ErrorCode.USER_INVALID_LOGIN_TYPE);
+
+        OauthToken oauthToken = getOauthToken(user.getUserId());
+        if(oauthToken == null) return;
+
+        System.out.println(oauthToken);
+
+        RestTemplate rt = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + oauthToken.getAccess_token());
+        HttpEntity<MultiValueMap<String, String>> logoutRequest = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<String> response = rt.exchange(
+                    "https://kapi.kakao.com/v1/user/logout",
+                    HttpMethod.POST,
+                    logoutRequest,
+                    String.class
+            );
+
+            System.out.println("회원번호 " + response.getBody() + " 로그아웃");
+            redisService.deleteValue(user.getUserId().toString());
+
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.AUTH_EXPIRED_ACCESS_TOKEN);
+        }
+
+    }
+
+    public boolean isExpired(Long userId) {
+
+        // OauthToken 정보를 받아와서 만료됐는지 검사
+        // 만료되었으면 true, 아직 유효하면 false
+        OauthToken oauthToken = (OauthToken) redisService.getValue(userId.toString());
+        if (oauthToken==null) return true;
+
+        RestTemplate rt = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + oauthToken.getAccess_token());
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(null, headers);
+
+        try {
+            ResponseEntity<OauthTokenInfoRes> response = rt.exchange(
+                    "https://kapi.kakao.com/v1/user/access_token_info",
+                    HttpMethod.GET,
+                    request,
+                    OauthTokenInfoRes.class
+            );
+            return false;
+        } catch (HttpClientErrorException ex) {
+            if (ex.getStatusCode() == HttpStatus.UNAUTHORIZED && ex.getResponseBodyAsString().contains("-401")) {
+                return true;
+            } else {
+                throw new CustomException(ErrorCode.AUTH_INVALID_KAKAO_CODE);
+            }
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.UNKNOWN_ERROR);
+        }
+    }
+
+    public OauthToken getRefresh(Long userId) {
+
+        // OauthToken을 refresh하는 메서드.
+        OauthToken oauthToken = (OauthToken) redisService.getValue(userId.toString());
+        if(oauthToken == null) return null;
+
+        RestTemplate rt = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "refresh_token");
+        params.add("client_id", clientId);
+        params.add("refresh_token", oauthToken.getRefresh_token());
+        params.add("client_secret", clientSecret);
+
+        HttpEntity<MultiValueMap<String, String>> refreshRequest = new HttpEntity<>(params, headers);
+
+        ResponseEntity<OauthToken> refreshResponse = rt.exchange(
+                "https://kauth.kakao.com/oauth/token",
+                HttpMethod.POST,
+                refreshRequest,
+                OauthToken.class
+        );
+        OauthToken refreshOauthToken = refreshResponse.getBody();
+        refreshOauthToken.setScope(oauthToken.getScope());
+
+        if (refreshOauthToken.getRefresh_token() == null) {
+            refreshOauthToken.setRefresh_token(oauthToken.getRefresh_token());
+        }
+        redisService.setValueWithTTL(userId.toString(), refreshOauthToken, 7L, TimeUnit.DAYS);
+
+        return refreshOauthToken;
+    }
+
+    public OauthToken getOauthToken(Long userId) {
+        OauthToken oauthToken;
+        if (isExpired(userId)) {
+            oauthToken = getRefresh(userId);
+        }else {
+            oauthToken = (OauthToken) redisService.getValue(userId.toString());
+        }
+
+        return oauthToken;
+    }
+}

--- a/src/main/java/com/turing/forseason/domain/user/service/KakaoAuthService.java
+++ b/src/main/java/com/turing/forseason/domain/user/service/KakaoAuthService.java
@@ -154,8 +154,7 @@ public class KakaoAuthService {
         // 서비스 로그아웃(카카오)
         UserEntity user = principalDetails.getUser();
 
-        if(user.getLoginType()!= LoginType.KAKAO)
-            throw new CustomException(ErrorCode.USER_INVALID_LOGIN_TYPE);
+        if(user.getLoginType()!= LoginType.KAKAO) return;
 
         OauthToken oauthToken = getOauthToken(user.getUserId());
         if(oauthToken == null) return;

--- a/src/main/java/com/turing/forseason/domain/user/service/KakaoAuthService.java
+++ b/src/main/java/com/turing/forseason/domain/user/service/KakaoAuthService.java
@@ -3,7 +3,7 @@ package com.turing.forseason.domain.user.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.turing.forseason.domain.user.domain.KakaoProfile;
-import com.turing.forseason.domain.user.dto.OauthTokenInfoRes;
+import com.turing.forseason.domain.user.dto.auth.OauthTokenInfoRes;
 import com.turing.forseason.domain.user.entity.LoginType;
 import com.turing.forseason.domain.user.entity.Role;
 import com.turing.forseason.domain.user.entity.UserEntity;
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit;
 @Transactional
 @RequiredArgsConstructor
 public class KakaoAuthService {
-    // 카카오 로그인 인증 관련 로직
+    // 카카오 로그인 관련 로직
     private final RedisService redisService;
     private final UserRepository userRepository;
     private final JwtTokenProvider tokenProvider;
@@ -145,7 +145,7 @@ public class KakaoAuthService {
         redisService.setValueWithTTL(user.getUserId().toString(), oauthToken, 7L, TimeUnit.DAYS);
 
         JwtTokenDto jwtTokenDto = tokenProvider.generateToken(user);
-        redisService.setValueWithTTL(jwtTokenDto.getRefreshToken(), user.getUserId(), 7L, TimeUnit.DAYS);
+        redisService.setValueWithTTL(jwtTokenDto.getRefreshToken(), user.getUserId().toString(), 7L, TimeUnit.DAYS);
 
         return jwtTokenDto;
     }

--- a/src/main/java/com/turing/forseason/domain/user/service/UserService.java
+++ b/src/main/java/com/turing/forseason/domain/user/service/UserService.java
@@ -70,7 +70,7 @@ public class UserService {
 
     public void signUpUser(SignUpRequestDto requestDto) {
         String state = (String) redisService.getValue(requestDto.getUserEmail());
-        if(!state.equals("verified")) throw new CustomException(ErrorCode.USER_EMAIL_AUTHENTICATION_STATUS_EXPIRED);
+        if(!"verified".equals(state)) throw new CustomException(ErrorCode.USER_EMAIL_AUTHENTICATION_STATUS_EXPIRED);
 
         UserEntity user = UserEntity.builder()
                 .userBoardNum(0L)
@@ -273,6 +273,7 @@ public class UserService {
             throw new CustomException(ErrorCode.USER_INVALID_LOGIN_TYPE);
 
         OauthToken oauthToken = (OauthToken) redisService.getValue(principalDetails.getUser().getUserId().toString());
+        // OauthToken이 널인지 아닌지 확인해야됨.
         System.out.println(oauthToken);
 
         RestTemplate rt = new RestTemplate();

--- a/src/main/java/com/turing/forseason/domain/user/service/UserService.java
+++ b/src/main/java/com/turing/forseason/domain/user/service/UserService.java
@@ -1,37 +1,16 @@
 package com.turing.forseason.domain.user.service;
 
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.turing.forseason.domain.user.domain.KakaoProfile;
+
 import com.turing.forseason.domain.user.dto.*;
-import com.turing.forseason.domain.user.entity.LoginType;
-import com.turing.forseason.domain.user.entity.Role;
 import com.turing.forseason.domain.user.entity.UserEntity;
 import com.turing.forseason.domain.user.repository.UserRepository;
 import com.turing.forseason.global.errorException.CustomException;
 import com.turing.forseason.global.errorException.ErrorCode;
-import com.turing.forseason.global.jwt.JwtTokenProvider;
-import com.turing.forseason.global.jwt.OauthToken;
-import com.turing.forseason.global.jwt.PrincipalDetails;
-import com.turing.forseason.global.mail.MailService;
-import com.turing.forseason.global.redis.RedisService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.*;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
-
-import javax.mail.MessagingException;
 import javax.servlet.http.HttpServletRequest;
-import java.util.NoSuchElementException;
-import java.util.concurrent.TimeUnit;
 
 @RequiredArgsConstructor
 @Service
@@ -39,13 +18,6 @@ import java.util.concurrent.TimeUnit;
 public class UserService {
 
     private final UserRepository userRepository;
-    private final JwtTokenProvider tokenProvider;
-    private final RedisService redisService;
-    private final MailService mailService;
-    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
-    private String clientSecret;
-    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
-    private String clientId;
 
     public UserEntity getUserById(Long userId) {
 
@@ -68,186 +40,6 @@ public class UserService {
         return user;
     }
 
-    public void signUpUser(SignUpRequestDto requestDto) {
-        String state = (String) redisService.getValue(requestDto.getUserEmail());
-        if(!"verified".equals(state)) throw new CustomException(ErrorCode.USER_EMAIL_AUTHENTICATION_STATUS_EXPIRED);
-
-        UserEntity user = UserEntity.builder()
-                .userBoardNum(0L)
-                .userCommentNum(0L)
-                .userEmail(requestDto.getUserEmail())
-                .userPassword(requestDto.getUserPassword())
-                .userNickname(requestDto.getUserNickname())
-                .userName(requestDto.getUserName())
-                .image(requestDto.getImage())
-                .thumbnail(requestDto.getImage())
-                .kakao_id(null)
-                .myRole(Role.MEMBER)
-                .loginType(LoginType.GENERAL)
-                .build();
-
-        userRepository.save(user);
-    }
-
-    public void verifyEmail(EmailVerificationDto emailVerificationDto) {
-        // 인증 코드 검사
-        String authCode = (String) redisService.getValue(emailVerificationDto.getUserEmail());
-
-        if(!emailVerificationDto.getCode().equals(authCode))
-            throw new CustomException(ErrorCode.USER_INVALID_EMAIL_AUTH_CODE);
-
-        redisService.setValueWithTTL(emailVerificationDto.getUserEmail(), "verified", 30, TimeUnit.MINUTES);
-    }
-
-    public boolean isDuplicatedEmail(String email) {
-        // 이메일 중복 검사 메서드
-        if(userRepository.existsByUserEmail(email))
-            throw new CustomException(ErrorCode.USER_DUPLICATED_USER_EMAIL);
-        return true;
-    }
-    @Async
-    public void sendEmailAuthCode(String email) {
-        // 해당 메서드는 메일 전송후, 잘 전송됐는지 검사까지 하므로 매우 처리시간이 김.
-        // 따라서 스레드 비동기 처리로 서버 처리 속도를 향상시킴.
-        // 이메일 인증 코드 전송하기
-
-        String authCode = mailService.generateCode();
-        System.out.println(authCode);
-
-        String body = "";
-        body += "<h3>" + "Forseason 이메일 인증 코드입니다." + "</h3>";
-        body += "<h1>" + authCode + "</h1>";
-        body += "<h3>" + "인증 코드는 30분간 유효합니다." + "</h3>";
-
-        try {
-            mailService.sendEmail(email, "[Forseason] 이메일 인증 코드", body);
-        } catch (Throwable e) {
-            throw new CustomException(ErrorCode.UNKNOWN_ERROR);
-        }
-
-        redisService.setValueWithTTL(email, authCode, 7L, TimeUnit.DAYS);
-    }
-
-
-    public String signInAndGetToken(SignInRequestDto requestDto) {
-        // Email, PW 검증 후 JWT 토큰 발급
-        UserEntity user = userRepository.findByUserEmail(requestDto.getUserEmail()).orElseThrow(
-                () -> new CustomException(ErrorCode.USER_INVALID_EMAIL));
-
-        if(!user.getUserPassword().equals(requestDto.getUserPassword()))
-            throw new CustomException(ErrorCode.USER_INVALID_PASSWORD);
-
-        return tokenProvider.generateToken(user);
-    }
-
-
-    public OauthToken getKakaoAccessToken (String code) {
-        RestTemplate rt = new RestTemplate();
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
-
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("grant_type", "authorization_code");
-        params.add("client_id", clientId);
-        params.add("redirect_uri", "http://localhost:3000/api/login/oauth2/code/kakao");
-        params.add("code", code);
-        params.add("client_secret", clientSecret);
-
-        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest =
-                new HttpEntity<>(params, headers);
-
-        ResponseEntity<String> accessTokenResponse = rt.exchange(
-                "https://kauth.kakao.com/oauth/token",
-                HttpMethod.POST,
-                kakaoTokenRequest,
-                String.class
-        );
-
-        ObjectMapper objectMapper = new ObjectMapper();
-        OauthToken oauthToken = null;
-        try {
-            oauthToken = objectMapper.readValue(accessTokenResponse.getBody(), OauthToken.class);
-        } catch (JsonProcessingException e) {
-            e.printStackTrace();
-        }
-
-        return oauthToken;
-    }
-
-    public KakaoProfile findProfile(OauthToken oauthToken) {
-
-        String accessToken = oauthToken.getAccess_token();
-
-        // HTTP 메세지 처리 인터페이스 선언
-        RestTemplate rt = new RestTemplate();
-
-
-        // 헤더정보에 token값과 content-type 설정 (kakao에서 지정한 필수 항목)
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", "Bearer " + accessToken); //(1-4)
-        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
-
-        // 위에서 설정한 헤더정보를 담는 HttpEntity 생성
-        HttpEntity<MultiValueMap<String, String>> kakaoProfileRequest = new HttpEntity<>(headers);
-
-        try {
-            // Http 요청 (POST 방식) 후, response 변수에 응답을 받음
-            ResponseEntity<KakaoProfile> kakaoProfileResponse = rt.exchange(
-                    "https://kapi.kakao.com/v2/user/me",
-                    HttpMethod.POST,
-                    kakaoProfileRequest,
-                    KakaoProfile.class
-            );
-
-            System.out.println(kakaoProfileResponse.getBody());
-            return kakaoProfileResponse.getBody();
-        } catch (Exception e) {
-            throw new CustomException(ErrorCode.AUTH_EXPIRED_ACCESS_TOKEN);
-        }
-
-    }
-
-
-    public String saveUserAndGetToken(OauthToken oauthToken) {
-
-        KakaoProfile profile = findProfile(oauthToken);
-
-        System.out.println(profile);
-
-        UserEntity user = null;
-
-        try {
-            user = userRepository.findByUserEmail(profile.getKakao_account().getEmail()).get();
-        } catch (NoSuchElementException e) {
-
-            String userName = "이름넣어줄건가요";
-            Long userBoardNum = 0L;
-            Long userCommentNum = 0L;
-
-
-            user = UserEntity.builder()
-                    .kakao_id(profile.getId())
-                    .image(profile.getKakao_account().getProfile().getProfile_image_url())
-                    .thumbnail(profile.getKakao_account().getProfile().getThumbnail_image_url())
-                    .userNickname(profile.getKakao_account().getProfile().getNickname())
-                    .userEmail(profile.getKakao_account().getEmail())
-                    .userPassword(null)
-                    .myRole(Role.MEMBER)
-                    .loginType(LoginType.KAKAO)
-                    .userName(userName)
-                    .userBoardNum(userBoardNum)
-                    .userCommentNum(userCommentNum)
-                    .build();
-
-            userRepository.save(user);
-        }
-        redisService.setValueWithTTL(user.getUserId().toString(), oauthToken, 7L, TimeUnit.DAYS);
-
-        return tokenProvider.generateToken(user);
-
-    }
-
     public UserEntity getUser(HttpServletRequest request) {
 
         Long userId = (Long) request.getAttribute("userId");
@@ -264,118 +56,4 @@ public class UserService {
         return new UserDetailDto(user);
     }
 
-
-    public void serviceLogout(PrincipalDetails principalDetails){
-        // 서비스 로그아웃(카카오)
-        UserEntity user = principalDetails.getUser();
-
-        if(user.getLoginType()!=LoginType.KAKAO)
-            throw new CustomException(ErrorCode.USER_INVALID_LOGIN_TYPE);
-
-        OauthToken oauthToken = getOauthToken(user.getUserId());
-        if(oauthToken == null) return;
-
-        System.out.println(oauthToken);
-
-        RestTemplate rt = new RestTemplate();
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", "Bearer " + oauthToken.getAccess_token());
-        HttpEntity<MultiValueMap<String, String>> logoutRequest = new HttpEntity<>(headers);
-
-        try {
-            ResponseEntity<String> response = rt.exchange(
-                    "https://kapi.kakao.com/v1/user/logout",
-                    HttpMethod.POST,
-                    logoutRequest,
-                    String.class
-            );
-
-            System.out.println("회원번호 " + response.getBody() + " 로그아웃");
-            redisService.deleteValue(user.getUserId().toString());
-
-        } catch (Exception e) {
-            throw new CustomException(ErrorCode.AUTH_EXPIRED_ACCESS_TOKEN);
-        }
-
-    }
-
-    public boolean isExpired(Long userId) {
-
-        // OauthToken 정보를 받아와서 만료됐는지 검사
-        // 만료되었으면 true, 아직 유효하면 false
-        OauthToken oauthToken = (OauthToken) redisService.getValue(userId.toString());
-        if (oauthToken==null) return true;
-
-        RestTemplate rt = new RestTemplate();
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", "Bearer " + oauthToken.getAccess_token());
-
-        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(null, headers);
-
-        try {
-            ResponseEntity<OauthTokenInfoRes> response = rt.exchange(
-                    "https://kapi.kakao.com/v1/user/access_token_info",
-                    HttpMethod.GET,
-                    request,
-                    OauthTokenInfoRes.class
-            );
-            return false;
-        } catch (HttpClientErrorException ex) {
-            if (ex.getStatusCode() == HttpStatus.UNAUTHORIZED && ex.getResponseBodyAsString().contains("-401")) {
-                return true;
-            } else {
-                throw new CustomException(ErrorCode.AUTH_INVALID_KAKAO_CODE);
-            }
-        } catch (Exception e) {
-            throw new CustomException(ErrorCode.UNKNOWN_ERROR);
-        }
-    }
-
-    public OauthToken getRefresh(Long userId) {
-
-        // OauthToken을 refresh하는 메서드.
-        OauthToken oauthToken = (OauthToken) redisService.getValue(userId.toString());
-        if(oauthToken == null) return null;
-
-        RestTemplate rt = new RestTemplate();
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
-
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("grant_type", "refresh_token");
-        params.add("client_id", clientId);
-        params.add("refresh_token", oauthToken.getRefresh_token());
-        params.add("client_secret", clientSecret);
-
-        HttpEntity<MultiValueMap<String, String>> refreshRequest = new HttpEntity<>(params, headers);
-
-        ResponseEntity<OauthToken> refreshResponse = rt.exchange(
-                "https://kauth.kakao.com/oauth/token",
-                HttpMethod.POST,
-                refreshRequest,
-                OauthToken.class
-        );
-        OauthToken refreshOauthToken = refreshResponse.getBody();
-        refreshOauthToken.setScope(oauthToken.getScope());
-
-        if (refreshOauthToken.getRefresh_token() == null) {
-            refreshOauthToken.setRefresh_token(oauthToken.getRefresh_token());
-        }
-        redisService.setValueWithTTL(userId.toString(), refreshOauthToken, 7L, TimeUnit.DAYS);
-
-        return refreshOauthToken;
-    }
-
-    public OauthToken getOauthToken(Long userId) {
-        OauthToken oauthToken;
-        if (isExpired(userId)) {
-            oauthToken = getRefresh(userId);
-        }else {
-            oauthToken = (OauthToken) redisService.getValue(userId.toString());
-        }
-
-        return oauthToken;
-    }
 }

--- a/src/main/java/com/turing/forseason/global/config/security/JwtSecurityConfig.java
+++ b/src/main/java/com/turing/forseason/global/config/security/JwtSecurityConfig.java
@@ -5,6 +5,7 @@ import com.turing.forseason.global.jwt.JwtAccessDeniedHandler;
 import com.turing.forseason.global.jwt.JwtAuthenticationEntryPoint;
 import com.turing.forseason.global.jwt.JwtRequestFilter;
 import com.turing.forseason.global.jwt.JwtTokenProvider;
+import com.turing.forseason.global.redis.RedisService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
@@ -16,9 +17,10 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
     private final JwtTokenProvider jwtTokenProvider;
+    private final RedisService redisService;
 
     @Override
     public void configure(HttpSecurity http) throws Exception{
-        http.addFilterBefore(new JwtRequestFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+        http.addFilterBefore(new JwtRequestFilter(jwtTokenProvider, redisService), UsernamePasswordAuthenticationFilter.class);
     }
 }

--- a/src/main/java/com/turing/forseason/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/turing/forseason/global/config/security/SecurityConfig.java
@@ -50,7 +50,8 @@ public class SecurityConfig {
                 .antMatchers(HttpMethod.OPTIONS).permitAll()
                 // 해당 URL에 대해 인증없이 접근 가능
                 .antMatchers("/api/**", "/auth/me", "/api/login/oauth2/code/kakao",
-                        "https://kauth.kakao.com/oauth/token", "https://kapi.kakao.com/v2/user/me", "/stomp/talk/**", "/talk/user/delete","/signup/**", "/signin/general").permitAll()
+                        "https://kauth.kakao.com/oauth/token", "https://kapi.kakao.com/v2/user/me", "/stomp/talk/**",
+                        "/talk/user/delete","/signup/**", "/signin/general", "/auth/reissue").permitAll()
                 // 위 URL 제외하고는 모두 인증필요
                 .anyRequest().authenticated()
 

--- a/src/main/java/com/turing/forseason/global/errorException/ErrorCode.java
+++ b/src/main/java/com/turing/forseason/global/errorException/ErrorCode.java
@@ -23,8 +23,8 @@ public enum ErrorCode {
     AUTH_INVALID_KAKAO_CODE(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.", 2007),
     AUTH_EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 엑세스 토큰입니다.", 2008),
     AUTH_BAD_LOGOUT_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다", 2009),
-    AUTH_INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "만료된 Refresh 토큰입니다.", 2010),
-    AUTH_BANNED_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "더 이상 사용되지 않는 Access 토큰입니다", 2011),
+    AUTH_DEPRECATED_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "만료된 Refresh 토큰입니다.", 2010),
+    AUTH_DEPRECATED_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "더 이상 사용되지 않는 Access 토큰입니다", 2011),
 
 
 

--- a/src/main/java/com/turing/forseason/global/errorException/ErrorCode.java
+++ b/src/main/java/com/turing/forseason/global/errorException/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     AUTH_INVALID_KAKAO_CODE(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.", 2007),
     AUTH_EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 엑세스 토큰입니다.", 2008),
     AUTH_BAD_LOGOUT_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다", 2009),
+    AUTH_INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "만료된 Refresh 토큰입니다.", 2010),
 
 
 

--- a/src/main/java/com/turing/forseason/global/errorException/ErrorCode.java
+++ b/src/main/java/com/turing/forseason/global/errorException/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     AUTH_EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 엑세스 토큰입니다.", 2008),
     AUTH_BAD_LOGOUT_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다", 2009),
     AUTH_INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "만료된 Refresh 토큰입니다.", 2010),
+    AUTH_BANNED_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "더 이상 사용되지 않는 Access 토큰입니다", 2011),
 
 
 

--- a/src/main/java/com/turing/forseason/global/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/turing/forseason/global/jwt/JwtAuthenticationEntryPoint.java
@@ -35,7 +35,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     private void setResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException{
         response.setContentType("application/json;charset=UTF-8");
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setStatus(errorCode.getHttpStatus().value());
 
         ApplicationErrorResponse errorResponse = new ApplicationErrorResponse(errorCode);
         ObjectMapper objectMapper = new ObjectMapper();

--- a/src/main/java/com/turing/forseason/global/jwt/JwtRequestFilter.java
+++ b/src/main/java/com/turing/forseason/global/jwt/JwtRequestFilter.java
@@ -45,7 +45,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
             if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
                 // Black List에 올라와 있는지 검사.
                 if("Deprecated".equals(redisService.getValue(jwt))){
-                    request.setAttribute("exception", ErrorCode.AUTH_BANNED_ACCESS_TOKEN);
+                    request.setAttribute("exception", ErrorCode.AUTH_DEPRECATED_ACCESS_TOKEN);
                     filterChain.doFilter(request, response);
                     return;
                 }

--- a/src/main/java/com/turing/forseason/global/jwt/JwtRequestFilter.java
+++ b/src/main/java/com/turing/forseason/global/jwt/JwtRequestFilter.java
@@ -8,6 +8,7 @@ import com.turing.forseason.domain.user.entity.UserEntity;
 import com.turing.forseason.domain.user.repository.UserRepository;
 import com.turing.forseason.global.errorException.CustomException;
 import com.turing.forseason.global.errorException.ErrorCode;
+import com.turing.forseason.global.redis.RedisService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AuthenticationServiceException;
@@ -29,6 +30,7 @@ import java.util.NoSuchElementException;
 @Component
 public class JwtRequestFilter extends OncePerRequestFilter {
     private final JwtTokenProvider tokenProvider;
+    private final RedisService redisService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -41,6 +43,13 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 
             // 유효성검사
             if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
+                // Black List에 올라와 있는지 검사.
+                if("Deprecated".equals(redisService.getValue(jwt))){
+                    request.setAttribute("exception", ErrorCode.AUTH_BANNED_ACCESS_TOKEN);
+                    filterChain.doFilter(request, response);
+                    return;
+                }
+
                 Authentication authentication = tokenProvider.getAuthentication(jwt);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             } else request.setAttribute("exception", ErrorCode.JWT_ABSENCE_TOKEN);

--- a/src/main/java/com/turing/forseason/global/jwt/JwtTokenDto.java
+++ b/src/main/java/com/turing/forseason/global/jwt/JwtTokenDto.java
@@ -1,0 +1,19 @@
+package com.turing.forseason.global.jwt;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class JwtTokenDto {
+    private String accessToken;
+    private String refreshToken;
+
+    @Builder
+    public JwtTokenDto(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/turing/forseason/global/redis/RedisService.java
+++ b/src/main/java/com/turing/forseason/global/redis/RedisService.java
@@ -27,7 +27,7 @@ public class RedisService {
         ValueOperations<String, Object> valueOperations = redisTemplate.opsForValue();
         Object object = valueOperations.get(key);
 
-        if(object==null) throw new CustomException(ErrorCode.REDIS_NOT_FOUND);
+//        if(object==null) throw new CustomException(ErrorCode.REDIS_NOT_FOUND);
 
         return object;
     }


### PR DESCRIPTION
# PR Summary
- #33

## PR Detail Description
주요 작업
- JWT 토큰을 **accessToken**과 **refreshToken**으로 분리. (accessToken 유효시간: 30분, refreshToken 유효시간: 일주일)
- refreshToken으로 accessToken을 재발급하는 **reissue** 로직 구현
- **reissue**시 기존의 refreshToken을 페기하는 로직 추가
- 로그아웃시 accessToken과 refreshToken을 Post로 전송하면, 해당 토큰들을 폐기하도록 로직 추가
- JwtRequestFilter에서 헤더로 들어온 accessToken이 폐기된 토큰인지 검증 로직 추가
- 기존 **UserService**를 카카오 로그인에 관련된 메서드들은 **KakaoAuthService**로, 일반 로그인에 관련된 메서드들은 **GeneralAuthService**로, 공통 인증 처리관련은 **AuthService**로 분리

주요 사항
- accessToken의 유효시간은 30분이므로, 프론트에서 accessToken 만료시, reissue API를 호출하여 access토큰과 refreshToken을 새로 발급받아야함.
- 토큰 탈취 시 큰 문제가 발생할 수 있기 때문에, 로그아웃과 같이 더이상 토큰이 필요하지 않을 경우 Redis에 저장하여 블랙리스트로 관리

## Screenshots (Optional)
토큰 폐기 로직:
![image](https://github.com/Turing-ForSeason/forseason-BE/assets/138233569/08399e81-02fc-4ff3-ba1e-ac0f06373146)
redis에 <token, "Deprecated">로 토큰 생명주기만큼 저장해둠.
따라서 사용자가 토큰이 필요한 리소스에 접근시, 토큰이 redis에 "Deprecated"로 저장되어있는지 검사하여 블랙리스트의 효과를 얻을 수 있음.

JwtRequestFilter의 로직을 수정하여,
![image](https://github.com/Turing-ForSeason/forseason-BE/assets/138233569/0127e92c-1038-4263-aa5b-0e8364a4146c)
access 토큰이 만료된 경우, 위 사진과 같이 401 status를 반환하고,

![image](https://github.com/Turing-ForSeason/forseason-BE/assets/138233569/9da93d1b-7816-487c-81a3-c2d133c09546)
access 토큰이 Deprecated인 경우, 400 status를 반환하도록 작성됨.


![image](https://github.com/Turing-ForSeason/forseason-BE/assets/138233569/00502698-68c9-4d5a-89cd-494afe536f95)
토큰이 만료된 경우, 위의 API를 호출하여, accessToken과 refreshToken을 재발급 받을 수 있음.