### PR TITLE
feat: JwtTokenDto 수정

### DIFF
--- a/src/main/java/com/turing/forseason/domain/user/service/KakaoAuthService.java
+++ b/src/main/java/com/turing/forseason/domain/user/service/KakaoAuthService.java
@@ -189,7 +189,7 @@ public class KakaoAuthService {
         // OauthToken 정보를 받아와서 만료됐는지 검사
         // 만료되었으면 true, 아직 유효하면 false
         OauthToken oauthToken = (OauthToken) redisService.getValue(userId.toString());
-        if (oauthToken==null) return true;
+        if (oauthToken == null) throw new CustomException(ErrorCode.AUTH_EXPIRED_OAUTH_TOKEN);
 
         RestTemplate rt = new RestTemplate();
 
@@ -221,7 +221,7 @@ public class KakaoAuthService {
 
         // OauthToken을 refresh하는 메서드.
         OauthToken oauthToken = (OauthToken) redisService.getValue(userId.toString());
-        if(oauthToken == null) return null;
+        if(oauthToken == null) throw new CustomException(ErrorCode.AUTH_EXPIRED_OAUTH_TOKEN);
 
         RestTemplate rt = new RestTemplate();
         HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/com/turing/forseason/domain/user/service/KakaoAuthService.java
+++ b/src/main/java/com/turing/forseason/domain/user/service/KakaoAuthService.java
@@ -142,7 +142,7 @@ public class KakaoAuthService {
 
             userRepository.save(user);
         }
-        redisService.setValueWithTTL(user.getUserId().toString(), oauthToken, 7L, TimeUnit.DAYS);
+        redisService.setValueWithTTL(user.getUserId().toString(), oauthToken, 50L, TimeUnit.DAYS); //OauthToken의 refreshToken이 대충 59일동안 유효함.
 
         JwtTokenDto jwtTokenDto = tokenProvider.generateToken(user);
         redisService.setValueWithTTL(jwtTokenDto.getRefreshToken(), user.getUserId().toString(), 7L, TimeUnit.DAYS);
@@ -210,7 +210,7 @@ public class KakaoAuthService {
             if (ex.getStatusCode() == HttpStatus.UNAUTHORIZED && ex.getResponseBodyAsString().contains("-401")) {
                 return true;
             } else {
-                throw new CustomException(ErrorCode.AUTH_INVALID_KAKAO_CODE);
+                throw new CustomException(ErrorCode.AUTH_KAKAO_SERVER_ERROR);
             }
         } catch (Exception e) {
             throw new CustomException(ErrorCode.UNKNOWN_ERROR);
@@ -247,7 +247,7 @@ public class KakaoAuthService {
         if (refreshOauthToken.getRefresh_token() == null) {
             refreshOauthToken.setRefresh_token(oauthToken.getRefresh_token());
         }
-        redisService.setValueWithTTL(userId.toString(), refreshOauthToken, 7L, TimeUnit.DAYS);
+        redisService.setValueWithTTL(userId.toString(), refreshOauthToken, 50L, TimeUnit.DAYS);
 
         return refreshOauthToken;
     }

--- a/src/main/java/com/turing/forseason/global/errorException/ErrorCode.java
+++ b/src/main/java/com/turing/forseason/global/errorException/ErrorCode.java
@@ -21,10 +21,11 @@ public enum ErrorCode {
     JWT_ABSENCE_TOKEN(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.", 2005),
     AUTH_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 정보의 사용자를 찾을 수 없습니다.", 2006),
     AUTH_KAKAO_SERVER_ERROR(HttpStatus.BAD_GATEWAY, "카카오 서버가 일시적 내부 장애상태 입니다", 2007),
-    AUTH_EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 엑세스 토큰입니다.", 2008),
-    AUTH_BAD_LOGOUT_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다", 2009),
-    AUTH_DEPRECATED_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "만료된 Refresh 토큰입니다.", 2010),
-    AUTH_DEPRECATED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "더 이상 사용되지 않는 Access 토큰입니다", 2011),
+    AUTH_EXPIRED_OAUTH_TOKEN(HttpStatus.BAD_REQUEST, "카카오로부터 정보를 받아올 수 없습니다. 다시 로그인해주세요.", 2008),
+    AUTH_EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 엑세스 토큰입니다.", 2009),
+    AUTH_BAD_LOGOUT_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다", 20010),
+    AUTH_DEPRECATED_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "만료된 Refresh 토큰입니다.", 2011),
+    AUTH_DEPRECATED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "더 이상 사용되지 않는 Access 토큰입니다", 2012),
 
 
 

--- a/src/main/java/com/turing/forseason/global/errorException/ErrorCode.java
+++ b/src/main/java/com/turing/forseason/global/errorException/ErrorCode.java
@@ -20,7 +20,7 @@ public enum ErrorCode {
     JWT_WRONG_TOKEN(HttpStatus.UNAUTHORIZED, "잘못된 JWT 토큰 입니다.", 2004),
     JWT_ABSENCE_TOKEN(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.", 2005),
     AUTH_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 정보의 사용자를 찾을 수 없습니다.", 2006),
-    AUTH_INVALID_KAKAO_CODE(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.", 2007),
+    AUTH_KAKAO_SERVER_ERROR(HttpStatus.BAD_GATEWAY, "카카오 서버가 일시적 내부 장애상태 입니다", 2007),
     AUTH_EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 엑세스 토큰입니다.", 2008),
     AUTH_BAD_LOGOUT_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다", 2009),
     AUTH_DEPRECATED_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "만료된 Refresh 토큰입니다.", 2010),

--- a/src/main/java/com/turing/forseason/global/errorException/ErrorCode.java
+++ b/src/main/java/com/turing/forseason/global/errorException/ErrorCode.java
@@ -24,7 +24,7 @@ public enum ErrorCode {
     AUTH_EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 엑세스 토큰입니다.", 2008),
     AUTH_BAD_LOGOUT_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다", 2009),
     AUTH_DEPRECATED_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "만료된 Refresh 토큰입니다.", 2010),
-    AUTH_DEPRECATED_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "더 이상 사용되지 않는 Access 토큰입니다", 2011),
+    AUTH_DEPRECATED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "더 이상 사용되지 않는 Access 토큰입니다", 2011),
 
 
 

--- a/src/main/java/com/turing/forseason/global/jwt/JwtTokenDto.java
+++ b/src/main/java/com/turing/forseason/global/jwt/JwtTokenDto.java
@@ -5,15 +5,20 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Date;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class JwtTokenDto {
     private String accessToken;
     private String refreshToken;
+    private Date accessTokenExpiresIn;
+
 
     @Builder
-    public JwtTokenDto(String accessToken, String refreshToken) {
+    public JwtTokenDto(String accessToken, String refreshToken, Date accessTokenExpiresIn) {
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
+        this.accessTokenExpiresIn = accessTokenExpiresIn;
     }
 }

--- a/src/main/java/com/turing/forseason/global/jwt/JwtTokenDto.java
+++ b/src/main/java/com/turing/forseason/global/jwt/JwtTokenDto.java
@@ -12,11 +12,11 @@ import java.util.Date;
 public class JwtTokenDto {
     private String accessToken;
     private String refreshToken;
-    private Date accessTokenExpiresIn;
+    private long accessTokenExpiresIn;
 
 
     @Builder
-    public JwtTokenDto(String accessToken, String refreshToken, Date accessTokenExpiresIn) {
+    public JwtTokenDto(String accessToken, String refreshToken, long accessTokenExpiresIn) {
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
         this.accessTokenExpiresIn = accessTokenExpiresIn;

--- a/src/main/java/com/turing/forseason/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/turing/forseason/global/jwt/JwtTokenProvider.java
@@ -53,6 +53,7 @@ public class JwtTokenProvider {
         return JwtTokenDto.builder()
                 .accessToken(TOKEN_PREFIX + accessToken)
                 .refreshToken(refreshToken)
+                .accessTokenExpiresIn(accessTokenExpiresIn)
                 .build();
     }
 

--- a/src/main/java/com/turing/forseason/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/turing/forseason/global/jwt/JwtTokenProvider.java
@@ -53,7 +53,7 @@ public class JwtTokenProvider {
         return JwtTokenDto.builder()
                 .accessToken(TOKEN_PREFIX + accessToken)
                 .refreshToken(refreshToken)
-                .accessTokenExpiresIn(accessTokenExpiresIn)
+                .accessTokenExpiresIn(accessTokenExpiresIn.getTime())
                 .build();
     }
 


### PR DESCRIPTION
# PR Summary
- close #39 
## PR Detail Description
주요 작업
- JwtTokenDto에 accessTokenExpiresIn 필드 추가
- JwtTokenProvider 로직 수정

주요 사항
- 기본적으로 로그인 시 accessToken과 refreshToken, accessTokenExpiresIn 이라는 필드가 담긴 JwtTokenDto를 서버로부터 반환받습니다.
- 여기서 accessToken은 인증이 필요한 API를 호출할때 사용되는 토큰으로써, 생명주기가 30분으로 짧습니다.
- refreshToken은 accessToken이 만료되었을때, 토큰 재발급을 위해 사용되며, 생명주기가 7주일로 비교적 깁니다.
- accessTokenExpiresIn은 필드명을 보면 알 수 있다시피, accessToken이 만료되는 시간을 long 타입으로 표현된 것입니다.
따라서 프론트에서 인증이 필요한 API를 호출할때, 취해야 할 로직은 다음과 같습니다.
1. 로그인 시, accessToken과 refreshToken, accessTokenExpiresIn을 모두 localStorage에 저장합니다.
2. 현재 보유한 accessToken이 다음과 같은 코드를 통하여 만료되었는지 검증합니다.
```
function isTokenExpired() {
    const storedExpiryTime = parseInt(localStorage.getItem('accessTokenExpiresIn'), 10); // localStorage에서 가져온 값을 정수로 변환
    const currentTime = Date.now(); // 현재 시간을 밀리초 단위로 가져옵니다.
    
    return currentTime >= storedExpiryTime; // 만료 시간이 현재 시간보다 같거나 작다면 true(토큰이 만료됨), 아니면 false
}
```

3.1. 아직 유효하다면, 4번으로 넘어갑니다.
3.2. 만료가 되었다면, refreshToken을 통해 Server의 reissue API를 호출하여, JwtTokenDto를 다시 발급받습니다. 이때, 로그인과 비슷하게 새로 발급받은 accessToken과 refreshToken, accessTokenExpiresIn들을 다시 localStorage에 저장합니다.
4. 헤더에 accessToken을 첨부하여 호출하고자 하는 API를 실행합니다.
## Screenshots (Optional)
