### PR TITLE
Feat: MyPageController 수정

### DIFF
--- a/src/main/java/com/turing/forseason/domain/user/controller/mypage/MyPageController.java
+++ b/src/main/java/com/turing/forseason/domain/user/controller/mypage/MyPageController.java
@@ -2,7 +2,6 @@ package com.turing.forseason.domain.user.controller.mypage;
 
 import com.turing.forseason.domain.user.dto.UpdateUserInfoRequest;
 import com.turing.forseason.domain.user.entity.UserEntity;
-import com.turing.forseason.domain.user.repository.UserRepository;
 import com.turing.forseason.domain.user.service.UserService;
 import com.turing.forseason.global.dto.ApplicationResponse;
 import com.turing.forseason.global.errorException.ErrorCode;
@@ -16,7 +15,6 @@ import org.springframework.web.bind.annotation.*;
 public class MyPageController {
 
     private final UserService userService;
-    private final UserRepository userRepository;
 
     @GetMapping("/mypage")
     public ApplicationResponse<UserEntity> getUser(@AuthenticationPrincipal PrincipalDetails principalDetails) {
@@ -42,9 +40,6 @@ public class MyPageController {
 
         // UserEntity의 update 메서드 호출 등 업데이트 작업 수행
         UserEntity updatedUserInfo = userService.update(principalDetails.getUser().getUserId(), request);
-
-        // 업데이트된 user를 저장
-        userRepository.save(updatedUserInfo);
 
         return ApplicationResponse.ok(ErrorCode.SUCCESS_OK, updatedUserInfo);
     }

--- a/src/main/java/com/turing/forseason/domain/user/controller/mypage/MyPageController.java
+++ b/src/main/java/com/turing/forseason/domain/user/controller/mypage/MyPageController.java
@@ -18,7 +18,7 @@ public class MyPageController {
     private final UserService userService;
     private final UserRepository userRepository;
 
-    @GetMapping("/mypage/{userId}")
+    @GetMapping("/mypage")
     public ApplicationResponse<UserEntity> getUser(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         //마이페이지 보기
 
@@ -27,7 +27,7 @@ public class MyPageController {
         return ApplicationResponse.ok(ErrorCode.SUCCESS_OK, user);
     }
 
-    @GetMapping("/mypage/editprofile/{userId}")
+    @GetMapping("/mypage/editprofile")
     public ApplicationResponse<UserEntity> getBeforeEditUser(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         //회원정보 수정 보기
 
@@ -36,7 +36,7 @@ public class MyPageController {
         return ApplicationResponse.ok(ErrorCode.SUCCESS_OK, user);
     }
 
-    @PostMapping("/mypage/editprofile/{id}")
+    @PostMapping("/mypage/editprofile")
     public ApplicationResponse<UserEntity> editUser(@AuthenticationPrincipal PrincipalDetails principalDetails, @RequestBody UpdateUserInfoRequest request) {
         //회원정보 수정
 

--- a/src/main/java/com/turing/forseason/domain/user/controller/mypage/MyPageController.java
+++ b/src/main/java/com/turing/forseason/domain/user/controller/mypage/MyPageController.java
@@ -7,7 +7,9 @@ import com.turing.forseason.domain.user.service.UserService;
 import com.turing.forseason.global.dto.ApplicationResponse;
 import com.turing.forseason.global.errorException.CustomException;
 import com.turing.forseason.global.errorException.ErrorCode;
+import com.turing.forseason.global.jwt.PrincipalDetails;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
@@ -21,29 +23,29 @@ public class MyPageController {
     private final UserRepository userRepository;
 
     @GetMapping("/mypage/{userId}")
-    public ApplicationResponse<UserEntity> getUser(@PathVariable long userId) {
+    public ApplicationResponse<UserEntity> getUser(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         //마이페이지 보기
 
-        UserEntity user = userService.getUserById(userId);
+        UserEntity user = userService.getUserById(principalDetails.getUser().getUserId());
 
         return ApplicationResponse.ok(ErrorCode.SUCCESS_OK, user);
     }
 
     @GetMapping("/mypage/editprofile/{userId}")
-    public ApplicationResponse<UserEntity> getBeforeEditUser(@PathVariable long userId) {
+    public ApplicationResponse<UserEntity> getBeforeEditUser(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         //회원정보 수정 보기
 
-        UserEntity user = userService.getUserById(userId);
+        UserEntity user = userService.getUserById(principalDetails.getUser().getUserId());
 
         return ApplicationResponse.ok(ErrorCode.SUCCESS_OK, user);
     }
 
     @PostMapping("/mypage/editprofile/{id}")
-    public ApplicationResponse<UserEntity> editUser(@PathVariable long userId, @RequestBody UpdateUserInfoRequest request) {
+    public ApplicationResponse<UserEntity> editUser(@AuthenticationPrincipal PrincipalDetails principalDetails, @RequestBody UpdateUserInfoRequest request) {
         //회원정보 수정
 
         // UserEntity의 update 메서드 호출 등 업데이트 작업 수행
-        UserEntity updatedUserInfo = userService.update(userId, request);
+        UserEntity updatedUserInfo = userService.update(principalDetails.getUser().getUserId(), request);
 
         // 업데이트된 user를 저장
         userRepository.save(updatedUserInfo);

--- a/src/main/java/com/turing/forseason/domain/user/controller/mypage/MyPageController.java
+++ b/src/main/java/com/turing/forseason/domain/user/controller/mypage/MyPageController.java
@@ -5,15 +5,11 @@ import com.turing.forseason.domain.user.entity.UserEntity;
 import com.turing.forseason.domain.user.repository.UserRepository;
 import com.turing.forseason.domain.user.service.UserService;
 import com.turing.forseason.global.dto.ApplicationResponse;
-import com.turing.forseason.global.errorException.CustomException;
 import com.turing.forseason.global.errorException.ErrorCode;
 import com.turing.forseason.global.jwt.PrincipalDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import javax.servlet.http.HttpServletRequest;
-import java.util.Optional;
 
 @RequiredArgsConstructor
 @RestController


### PR DESCRIPTION
# PR Summary

- fixes #38 

## PR Detail Description

MyPageController를 변경된 사항에 맞게 고치고, 잘못된 로직을 수정했습니다.

- getUser, getBeforeEditUser, editUser 메서드에 매핑된 url을 수정했습니다.
- `@AuthenticationPrincipal` 을 사용해 로그인 된 사용자의 정보를 받아오도록 수정했습니다.
- editUser 메서드에서 userRepository를 사용하는 불필요한 로직을 삭제했습니다.
